### PR TITLE
Make compatible with latest jquery version & add styling functionailty

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,10 @@ Read the wiki for design decisions we have made and why.
 			</div>
 		</div>
 	</div>
+	<!-- The elements you want repeated must be wrapped in an element with id="recordset" which needs to have a parent element with id="recordset".-->
 	```
-	
-2. Add to the buttom of the page and you are done. 
+
+2. Add to the buttom of the page and you are done.
 
 	```javascript
 	<script src="js/jquery.czMore-1.5.3.2.js"></script>
@@ -37,8 +38,8 @@ Notice that the field above has "_1_" in it's name and id, this will be changed 
 In case you need to know how many fields where added in the client side the plugin drops a field with count of the number that is.
 
 ```html
-<input id="czContainer_czMore_txtCount" 
-	   name="czContainer_czMore_txtCount" 
+<input id="czContainer_czMore_txtCount"
+	   name="czContainer_czMore_txtCount"
 	   type="hidden" value="0" size="5" />
 ```
 
@@ -52,3 +53,12 @@ This field will be named after your container, so that if you use other instance
   This will be executed sometime during loading but it's not implemented now
 ### onDelete
   This will be executed before deleting a row or field
+
+## Styling
+  This plugin sets the default css for the plus and minus buttons you can disable
+  the styling like the example below and  then add your own styles using the
+`.btnPlus` and `.btnMinus` css classes
+
+```javascript
+		$('#czContainer').czMore({styleOverride: true})
+```

--- a/js/jquery.czMore-latest.js
+++ b/js/jquery.czMore-latest.js
@@ -16,7 +16,8 @@ MIT License, https://github.com/cozeit/czMore/blob/master/LICENSE.md
             min: 0,
             onLoad: null,
             onAdd: null,
-            onDelete: null
+            onDelete: null,
+            styleOverride: false,
         };
         //Update unset options with defaults if needed
         var options = $.extend(defaults, options);
@@ -32,8 +33,8 @@ MIT License, https://github.com/cozeit/czMore/blob/master/LICENSE.md
         //Executing functionality on all selected elements
         return this.each(function () {
             var obj = $(this);
-            var i = obj.children(".recordset").size();
-            var divPlus = '<div id="btnPlus" />';
+            var i = obj.children(".recordset").length;
+            var divPlus = '<div id="btnPlus" class="btnPlus"/>';
             var count = '<input id="' + this.id + '_czMore_txtCount" name="' + this.id + '_czMore_txtCount" type="hidden" value="0" size="5" />';
 
             obj.before(count);
@@ -42,20 +43,22 @@ MIT License, https://github.com/cozeit/czMore/blob/master/LICENSE.md
             var set = recordset.children(".recordset").children().first();
             var btnPlus = obj.siblings("#btnPlus");
 
-            btnPlus.css({
-                'float': 'right',
-                'border': '0px',
-                'background-image': 'url("img/add.png")',
-                'background-position': 'center center',
-                'background-repeat': 'no-repeat',
-                'height': '25px',
-                'width': '25px',
-                'cursor': 'pointer'
-            });
+            if(!options.styleOverride) {
+              btnPlus.css({
+                  'float': 'right',
+                  'border': '0px',
+                  'background-image': 'url("img/add.png")',
+                  'background-position': 'center center',
+                  'background-repeat': 'no-repeat',
+                  'height': '25px',
+                  'width': '25px',
+                  'cursor': 'pointer',
+              });
+            }
 
             if (recordset.length) {
                 obj.siblings("#btnPlus").click(function () {
-                    var i = obj.children(".recordset").size();
+                    var i = obj.children(".recordset").length;
                     var item = recordset.clone().html();
                     i++;
                     item = item.replace(/\[([0-9]\d{0})\]/g, "[" + i + "]");
@@ -105,28 +108,30 @@ MIT License, https://github.com/cozeit/czMore/blob/master/LICENSE.md
             }
 
             function loadMinus(recordset) {
-                var divMinus = '<div id="btnMinus" />';
+                var divMinus = '<div id="btnMinus" class="btnMinus" />';
                 $(recordset).children().first().before(divMinus);
                 var btnMinus = $(recordset).children("#btnMinus");
-                btnMinus.css({
-                    'float': 'right',
-                    'border': '0px',
-                    'background-image': 'url("img/remove.png")',
-                    'background-position': 'center center',
-                    'background-repeat': 'no-repeat',
-                    'height': '25px',
-                    'width': '25px',
-                    'cursor': 'poitnter'
-                });
+                if(!options.styleOverride) {
+                  btnMinus.css({
+                      'float': 'right',
+                      'border': '0px',
+                      'background-image': 'url("img/remove.png")',
+                      'background-position': 'center center',
+                      'background-repeat': 'no-repeat',
+                      'height': '25px',
+                      'width': '25px',
+                      'cursor': 'poitnter',
+                  });
+              }
             }
 
             function minusClick(recordset) {
                 $(recordset).children("#btnMinus").click(function () {
-                    var i = obj.children(".recordset").size();
+                    var i = obj.children(".recordset").length;
                     var id = $(recordset).attr("data-id")
                     $(recordset).remove();
                     resetNumbering();
-                    obj.siblings("input[name$='czMore_txtCount']").val(obj.children(".recordset").size());
+                    obj.siblings("input[name$='czMore_txtCount']").val(obj.children(".recordset").length);
                     i--;
                     if (options.onDelete != null) {
                         if (id != null)


### PR DESCRIPTION
The size() method was deprecated in version 1.8 and removed in jQuery version 3.0. Replaced with length property instead.

Functionality to add own css style to buttons by adding a class to the add and remove button and adding an extra item to the options object. See updated readme file for more details
